### PR TITLE
Ignore anonymous helpers

### DIFF
--- a/lib/tapioca/dsl/compilers/grape_endpoints.rb
+++ b/lib/tapioca/dsl/compilers/grape_endpoints.rb
@@ -137,14 +137,10 @@ module Tapioca
         def create_endpoint_class
           superclass = "::Grape::Endpoint"
 
-          helper_mods = constant.namespace_stackable(:helpers)
-
-          if helper_mods.any? { |mod| mod.name.nil? }
-            raise "Cannot compile Grape API with anonymous helpers"
-          end
+          named_helper_mods = constant.namespace_stackable(:helpers).reject { |mod| mod.name.nil? }
 
           api.create_class(EndpointClassName, superclass_name: superclass) do |klass|
-            helper_mods.each do |mod|
+            named_helper_mods.each do |mod|
               klass.create_include(mod.name)
             end
           end

--- a/rbi/grape.rbi
+++ b/rbi/grape.rbi
@@ -22,6 +22,11 @@ module Grape
         sig { params(name: Symbol, block: T.proc.bind(Grape::Validations::ParamsScope).void).void }
         def params(name, &block); end
       end
+
+      module ClassMethods
+        sig { params(new_modules: T.untyped, block: T.nilable(T.proc.bind(Grape::DSL::Helpers::BaseHelper).void)).void }
+        def helpers(*new_modules, &block); end
+      end
     end
 
     module RequestResponse


### PR DESCRIPTION
Ignore anonymous helpers instead of raising an exception.

The Tapioca compiler requires helper methods to be declared inside a named module rather than an anonymous `helpers do ... end` block in order to generate a proper RBI definition that Sorbet can use to know that the helper methods exist.

The initial version of the Tapioca compiler raised an exception when encountering anonymous `helpers do ... end` blocks to help enforce this. However this is at least one case in which the block form of `helpers` must be used: defining reusable params, e.g.:

```ruby
  helpers do
    params :pagination do
      optional :page, type: Integer
      optional :per_page, type: Integer
    end
  end
```

This PR updates the compiler to simply skip over anonymous helpers blocks.