### PR TITLE
Add signatures for `error!` and a few other methods

### DIFF
--- a/rbi/grape.rbi
+++ b/rbi/grape.rbi
@@ -29,6 +29,26 @@ module Grape
       end
     end
 
+    module InsideRoute
+      sig do
+        params(
+          message: T.any(String, T::Hash[Symbol, T.untyped]),
+          status: T.nilable(T.any(Integer, Symbol)),
+          additional_headers: T.nilable(T::Hash[String, String]),
+        ).returns(T.noreturn)
+      end
+      def error!(message, status = nil, additional_headers = nil); end
+
+      sig { params(status: T.nilable(T.any(Integer, Symbol))).returns(Integer) }
+      def status(status = nil); end
+
+      sig { returns(Grape::Cookies) }
+      def cookies; end
+
+      sig { returns(Grape::Router::Route) }
+      def route; end
+    end
+
     module RequestResponse
       module ClassMethods
         sig { params(args: T.untyped, block: T.proc.bind(Grape::Endpoint).params(e: Exception).void).void }


### PR DESCRIPTION
Add signatures for `error!` and a few other methods.

Primarily, type `error!` as returning `T.noreturn` so that Sorbet knows that `error!` never returns.
