### PR TITLE
Improve types for `rescue_from`

### DIFF
--- a/lib/tapioca/dsl/compilers/grape_endpoints.rb
+++ b/lib/tapioca/dsl/compilers/grape_endpoints.rb
@@ -172,16 +172,30 @@ module Tapioca
 
         sig { void }
         def create_request_response_methods
-          request_response_methods_module.create_method(
+          sigs = [
+            request_response_methods_module.create_sig(
+              parameters: {
+                args: "Symbol",
+                block: "T.nilable(T.proc.bind(#{EndpointClassName}).params(e: Exception).void)",
+              },
+              return_type: "void",
+            ),
+            request_response_methods_module.create_sig(
+              type_parameters: ["E"],
+              parameters: {
+                args: "T::Class[T.all(::Exception, T.type_parameter(:E))]",
+                block: "T.nilable(T.proc.bind(#{EndpointClassName}).params(e: T.type_parameter(:E)).void)",
+              },
+              return_type: "void",
+            ),
+          ]
+          request_response_methods_module.create_method_with_sigs(
             "rescue_from",
+            sigs: sigs,
             parameters: [
-              create_rest_param("args", type: "T.untyped"),
-              create_block_param(
-                "block",
-                type: "T.nilable(T.proc.bind(#{EndpointClassName}).params(e: Exception).void)",
-              ),
+              RBI::RestParam.new("args"),
+              RBI::BlockParam.new("block"),
             ],
-            return_type: "void",
           )
         end
 

--- a/rbi/grape.rbi
+++ b/rbi/grape.rbi
@@ -51,7 +51,15 @@ module Grape
 
     module RequestResponse
       module ClassMethods
-        sig { params(args: T.untyped, block: T.proc.bind(Grape::Endpoint).params(e: Exception).void).void }
+        sig { params(args: Symbol, block: T.nilable(T.proc.bind(Grape::Endpoint).params(e: Exception).void)).void }
+        sig do
+          type_parameters(:E)
+            .params(
+              args: T::Class[T.all(Exception, T.type_parameter(:E))],
+              block: T.proc.bind(Grape::Endpoint).params(e: T.type_parameter(:E)).void,
+            )
+            .void
+        end
         def rescue_from(*args, &block); end
       end
     end

--- a/spec/tapioca/dsl/compilers/grape_endpoints_spec.rb
+++ b/spec/tapioca/dsl/compilers/grape_endpoints_spec.rb
@@ -85,7 +85,8 @@ module Tapioca
                   end
 
                   module GeneratedRequestResponseMethods
-                    sig { params(args: T.untyped, block: T.nilable(T.proc.bind(PrivateEndpoint).params(e: Exception).void)).void }
+                    sig { params(args: Symbol, block: T.nilable(T.proc.bind(PrivateEndpoint).params(e: Exception).void)).void }
+                    sig { type_parameters(:E).params(args: T::Class[T.all(::Exception, T.type_parameter(:E))], block: T.nilable(T.proc.bind(PrivateEndpoint).params(e: T.type_parameter(:E)).void)).void }
                     def rescue_from(*args, &block); end
                   end
 
@@ -177,7 +178,8 @@ module Tapioca
                   end
 
                   module GeneratedRequestResponseMethods
-                    sig { params(args: T.untyped, block: T.nilable(T.proc.bind(PrivateEndpoint).params(e: Exception).void)).void }
+                    sig { params(args: Symbol, block: T.nilable(T.proc.bind(PrivateEndpoint).params(e: Exception).void)).void }
+                    sig { type_parameters(:E).params(args: T::Class[T.all(::Exception, T.type_parameter(:E))], block: T.nilable(T.proc.bind(PrivateEndpoint).params(e: T.type_parameter(:E)).void)).void }
                     def rescue_from(*args, &block); end
                   end
 


### PR DESCRIPTION
Better types for `rescue_from`.

Before this change, the `e` argument received by the block passed to `rescue_from` was typed as `Exception`. This was annoying if you wanted to do something like this:

```ruby
rescue_from Grape::Exceptions::ValidationErrors do |e|
  error!({ messages: e.full_messages }, 400)
end
```

you'd be forced to cast `e` to the proper type:

```ruby
rescue_from Grape::Exceptions::ValidationErrors do |e|
  e = T.cast(e, Grape::Exceptions::ValidationErrors)
  error!({ messages: e.full_messages }, 400)
end
```

With this PR, this is now unnecessary:

```ruby
rescue_from Grape::Exceptions::ValidationErrors do |e|
  T.reveal_type(e) # => Grape::Exceptions::ValidationErrors
  error!({ messages: e.full_messages }, 400)
end
```