### PR TITLE
Add support for `options` param in `params` type signature

### DIFF
--- a/rbi/grape.rbi
+++ b/rbi/grape.rbi
@@ -19,12 +19,22 @@ module Grape
 
     module Helpers
       module BaseHelper
-        sig { params(name: Symbol, block: T.proc.bind(Grape::Validations::ParamsScope).void).void }
+        sig do
+          params(
+            name: Symbol,
+            block: T.proc.bind(Grape::Validations::ParamsScope).params(options: T::Hash[Symbol, T.untyped]).void,
+          ).void
+        end
         def params(name, &block); end
       end
 
       module ClassMethods
-        sig { params(new_modules: T.untyped, block: T.nilable(T.proc.bind(Grape::DSL::Helpers::BaseHelper).void)).void }
+        sig do
+          params(
+            new_modules: T.untyped,
+            block: T.nilable(T.proc.bind(Grape::DSL::Helpers::BaseHelper).void),
+          ).void
+        end
         def helpers(*new_modules, &block); end
       end
     end


### PR DESCRIPTION
E.g.

```ruby
  params :order do |options|
    optional :order_by, type: Symbol, values: options[:order_by], default: options[:default_order_by]
    optional :order, type: Symbol, values: %i(asc desc), default: options[:default_order]
  end
```

this update properly types `options` as `T::Hash[Symbol, T.untyped]`.