### PR TITLE
Introduce GrapeSorbet::TypedEntity

### DIFF
--- a/lib/grape_sorbet.rb
+++ b/lib/grape_sorbet.rb
@@ -6,3 +6,4 @@ end
 
 require_relative "grape_sorbet/version"
 require_relative "grape_sorbet/grape_entity_name"
+require_relative "grape_sorbet/typed_entity"

--- a/lib/grape_sorbet/typed_entity.rb
+++ b/lib/grape_sorbet/typed_entity.rb
@@ -1,0 +1,112 @@
+# typed: strict
+# frozen_string_literal: true
+
+begin
+  require "grape-entity"
+rescue LoadError
+  return
+end
+
+require "sorbet-runtime"
+
+module GrapeSorbet
+  # A Sorbet-typed version of `Grape::Entity`.
+  #
+  # This class works like `Grape::Entity`, with a few key differences:
+  # - `expose` can only be used for basic exposure of attributes, and can only expose one attribute at a time.
+  # - For runtime exposure, use `expose_runtime` instead of `expose`.
+  # - For nested exposure, use `expose_nested` instead of `expose`.
+  #
+  # In order for Sorbet to know the type of the object being exposed in runtime exposures (i.e. the first argument to
+  # the exposure block), you need to use `ObjectTypeTemplate`.
+  #
+  # In order for Sorbet to know the type of the object being exposed in helper methods via `object`, you need to set
+  # `ObjectTypeMember`.
+  #
+  # You don't have to set both, e.g. there is no need to set `ObjectTypeMember` if your entity does not have any helper
+  # methods calling `object`. However, if you do set both, they should always be set to the same type.
+  #
+  # Example:
+  # ```
+  # module API
+  #   module Entities
+  #     class User < GrapeSorbet::TypedEntity
+  #       ObjectTypeMember = type_member { { fixed: ::User } }
+  #       ObjectTypeTemplate = type_template { { fixed: ::User } }
+  #
+  #       expose :id
+  #
+  #       expose_runtime :name do |user|
+  #         # T.reveal_type(user) # => ::User
+  #         user.profile.name
+  #       end
+  #
+  #       expose_nested :contact_info do
+  #         expose_runtime :phone do |user|
+  #           user.profile.phone_number
+  #         end
+  #       end
+  #
+  #       expose :number_of_friends
+  #
+  #       private
+  #
+  #       sig { returns(Integer) }
+  #       def number_of_friends
+  #         # T.reveal_type(object) # => User
+  #         object.friends.count
+  #       end
+  #     end
+  #   end
+  # end
+  # ```
+  class TypedEntity < Grape::Entity
+    extend T::Sig
+    extend T::Helpers
+    extend T::Generic
+
+    abstract!
+
+    ObjectTypeMember = type_member
+    ObjectTypeTemplate = type_template
+
+    class << self
+      extend T::Sig
+
+      sig { params(attribute: Symbol, options: T::Hash[Symbol, T.untyped]).void }
+      def expose(attribute, options = {})
+        super(attribute, options)
+      end
+
+      sig do
+        params(
+          attribute: Symbol,
+          options: T::Hash[Symbol, T.untyped],
+          block: T.proc.bind(T.attached_class).params(
+            object: ObjectTypeTemplate,
+            options: T::Hash[Symbol, T.untyped],
+          ).returns(T.untyped),
+        ).void
+      end
+      def expose_runtime(attribute, options = {}, &block)
+        T.must(method(:expose).super_method).call(attribute, options, &block)
+      end
+
+      sig do
+        params(
+          attribute: Symbol,
+          options: T::Hash[Symbol, T.untyped],
+          block: T.proc.bind(T.self_type).void,
+        ).void
+      end
+      def expose_nested(attribute, options = {}, &block)
+        T.must(method(:expose).super_method).call(attribute, options, &block)
+      end
+    end
+
+    sig { returns(ObjectTypeMember) }
+    def object
+      super
+    end
+  end
+end

--- a/spec/grape_sorbet/typed_entity_spec.rb
+++ b/spec/grape_sorbet/typed_entity_spec.rb
@@ -1,0 +1,81 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module GrapeSorbet
+  class TypedEntitySpec < Minitest::Spec
+    describe "GrapeSorbet::TypedEntity" do
+      class Person < T::Struct
+        const :name, String
+        const :age, Integer
+      end
+
+      class PersonEntity < GrapeSorbet::TypedEntity
+        ObjectTypeMember = type_member { { fixed: Person } }
+        ObjectTypeTemplate = type_template { { fixed: Person } }
+
+        expose :name
+
+        expose_runtime :age do |person|
+          # T.reveal_type(self) # => PersonEntity
+          # T.reveal_type(person) # => Person
+          age_in_years(person)
+        end
+
+        expose_nested :profile do
+          # T.reveal_type(self) # => T.class_of(PersonEntity)
+          expose :age
+        end
+
+        expose :age_squared
+
+        private
+
+        sig { params(person: Person).returns(String) }
+        def age_in_years(person)
+          "#{person.age} years"
+        end
+
+        sig { returns(Integer) }
+        def age_squared
+          # T.reveal_type(object) # => Person
+          object.age * object.age
+        end
+      end
+
+      describe ".expose" do
+        it "exposes the attribute" do
+          person = Person.new(name: "John", age: 30)
+          entity = PersonEntity.represent(person)
+          puts entity.to_json
+          assert_equal("John", entity.as_json[:name])
+        end
+      end
+
+      describe ".expose_runtime" do
+        it "exposes the return value of the block exposure" do
+          person = Person.new(name: "John", age: 30)
+          entity = PersonEntity.represent(person)
+          assert_equal("30 years", entity.as_json[:age])
+        end
+      end
+
+      describe ".expose_nested" do
+        it "can expose attributes from within the nested exposure" do
+          person = Person.new(name: "John", age: 30)
+          entity = PersonEntity.represent(person)
+          assert_equal(30, entity.as_json[:profile][:age])
+        end
+      end
+
+      describe "#object" do
+        it "returns the object being represented" do
+          person = Person.new(name: "John", age: 30)
+          entity = PersonEntity.represent(person)
+          assert_equal(person, entity.object)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces a new `GrapeSorbet::TypedEntity` class, which adds type safety to `Grape::Entity`.

Closes #15.
